### PR TITLE
Use correct shebang in the main Python 3 script

### DIFF
--- a/waydroid-settings.py
+++ b/waydroid-settings.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 import sys
 import gi
 import utils


### PR DESCRIPTION
Better to be explicit about the requested interpreter version.

This was reportedly still a problem on Ubuntu 22.04: https://t.me/WayDroid/107206

Closes #3.